### PR TITLE
Poller task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,19 +31,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "async-channel"
@@ -322,6 +328,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -927,6 +947,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1081,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,12 +1124,24 @@ dependencies = [
 name = "mb-exurl-ia-service"
 version = "0.1.0"
 dependencies = [
- "regex",
+ "linkify",
+ "mb-rs",
  "reqwest",
  "serde_json",
  "sqlx",
  "tokio",
  "tokio-postgres",
+]
+
+[[package]]
+name = "mb-rs"
+version = "0.1.0"
+source = "git+https://github.com/yellowHatpro/Rust-Playground.git#f7a57963ac586ee240d36b70ea7bc717dda1e340"
+dependencies = [
+ "chrono",
+ "serde_json",
+ "sqlx",
+ "uuid",
 ]
 
 [[package]]
@@ -1534,35 +1598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
-
-[[package]]
 name = "reqwest"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,6 +1938,7 @@ dependencies = [
  "atoi",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -1927,8 +1963,11 @@ dependencies = [
  "smallvec",
  "sqlformat",
  "thiserror",
+ "tokio",
+ "tokio-stream",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1967,6 +2006,7 @@ dependencies = [
  "sqlx-sqlite",
  "syn 1.0.109",
  "tempfile",
+ "tokio",
  "url",
 ]
 
@@ -1981,6 +2021,7 @@ dependencies = [
  "bitflags 2.5.0",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -2009,6 +2050,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -2022,6 +2064,7 @@ dependencies = [
  "base64 0.21.7",
  "bitflags 2.5.0",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -2047,6 +2090,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -2057,6 +2101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",
@@ -2071,6 +2116,7 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]
@@ -2253,6 +2299,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2444,15 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "uuid"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "value-bag"
@@ -2541,6 +2607,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1072,7 @@ dependencies = [
 name = "mb-exurl-ia-service"
 version = "0.1.0"
 dependencies = [
+ "regex",
  "reqwest",
  "serde_json",
  "sqlx",
@@ -1522,6 +1532,35 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ tokio = {version = "1.37.0", features = ["full"]}
 sqlx = {version = "0.7.4", features = ["runtime-async-std-native-tls","postgres"]}
 reqwest = "0.12.4"
 serde_json = "1.0.116"
+regex = "1.10.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ tokio = {version = "1.37.0", features = ["full"]}
 sqlx = {version = "0.7.4", features = ["runtime-async-std-native-tls","postgres"]}
 reqwest = "0.12.4"
 serde_json = "1.0.116"
-regex = "1.10.4"
+linkify = "0.10.0"
+mb-rs = {git = "https://github.com/yellowHatpro/Rust-Playground.git"}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,24 @@
+use sqlx::postgres::PgPoolOptions;
+use crate::poller::Poller;
+
 mod poller;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const POLL_INTERVAL: u64 = 30;
+    //NOTE: for time being, keeping the db_url to a custom db, will check with mb schema later
+    let db_url = "postgres://yellowhatpro@localhost:5432";
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&db_url)
+        .await
+        .unwrap();
+
+    let poller = Poller::new(POLL_INTERVAL, pool);
+    tokio::spawn(async move {
+        poller
+            .poll()
+            .await;
+    });
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,9 @@ mod poller;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    const POLL_INTERVAL: u64 = 30;
+    const POLL_INTERVAL: u64 = 10;
     //NOTE: for time being, keeping the db_url to a custom db, will check with mb schema later
-    let db_url = "postgres://yellowhatpro@localhost:5432";
+    let db_url = "postgres://musicbrainz:musicbrainz@localhost:5432/musicbrainz_db";
     let pool = PgPoolOptions::new()
         .max_connections(5)
         .connect(&db_url)
@@ -19,6 +19,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         poller
             .poll()
             .await;
-    });
+    }).await.unwrap();
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .unwrap();
 
-    let poller = Poller::new(POLL_INTERVAL, pool);
+    let mut poller = Poller::new(POLL_INTERVAL, pool);
     tokio::spawn(async move {
         poller
+            .await
             .poll()
             .await;
     }).await.unwrap();

--- a/src/poller/internet_archive_urls.rs
+++ b/src/poller/internet_archive_urls.rs
@@ -1,0 +1,17 @@
+#![allow(dead_code)]
+// Generated with sql-gen
+// https://github.com/jayy-lmao/sql-gen
+//TODO: move this to mb-rs
+use sqlx::types::chrono;
+
+#[derive(sqlx::FromRow, Debug)]
+pub struct InternetArchiveUrls {
+    pub id: i32,
+    pub url: Option<String>,
+    pub job_id: Option<String>,
+    pub from_table: Option<String>,
+    pub from_table_id: Option<i32>,
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub retry_count: Option<i32>,
+    pub is_saved: Option<bool>,
+}

--- a/src/poller/looper.rs
+++ b/src/poller/looper.rs
@@ -3,18 +3,21 @@ use sqlx::{Error};
 use crate::poller::utils::{extract_url_from_edit_data, extract_urls_from_edit_note};
 
 pub async fn poll_db(
-    pool: &sqlx::PgPool
+    pool: &sqlx::PgPool,
+    edit_data_start_idx: i32,
+    edit_note_start_idx: i32
 ) -> Result<(), Error> {
+    println!("EditNote: {}, EditData: {}", edit_note_start_idx, edit_data_start_idx);
     let edits = sqlx::query_as::<_, EditData>(
-        "SELECT * FROM edit_data LIMIT 10")
+        r#"SELECT * FROM edit_data WHERE "edit" > $1 ORDER BY edit LIMIT 10"#)
+        .bind(edit_data_start_idx)
         .fetch_all(pool)
         .await?;
-
     let notes = sqlx::query_as::<_, EditNote>(
-        "SELECT * FROM edit_note LIMIT 10")
+        r#"SELECT * FROM edit_note WHERE "id" > $1 ORDER BY id LIMIT 10"#)
+        .bind(edit_note_start_idx)
         .fetch_all(pool)
         .await?;
-
     //TODO: transformations, and save transformed data to internet_archive_urls
     println!("Edits ->");
     for edit in edits {

--- a/src/poller/looper.rs
+++ b/src/poller/looper.rs
@@ -1,16 +1,32 @@
-use sqlx::{Error, Row};
+use mb_rs::schema::{EditData, EditNote};
+use sqlx::{Error};
+use crate::poller::utils::{extract_url_from_edit_data, extract_urls_from_edit_note};
 
 pub async fn poll_db(
     pool: &sqlx::PgPool
 ) -> Result<(), Error> {
-    //TODO: perform the edit_note and edit_data
-    let rows = sqlx::query(
+    let edits = sqlx::query_as::<_, EditData>(
         "SELECT * FROM edit_data LIMIT 10")
         .fetch_all(pool)
         .await?;
+
+    let notes = sqlx::query_as::<_, EditNote>(
+        "SELECT * FROM edit_note LIMIT 10")
+        .fetch_all(pool)
+        .await?;
+
     //TODO: transformations, and save transformed data to internet_archive_urls
-    for row in rows {
-        println!("{:?}", row.columns());
+    println!("Edits ->");
+    for edit in edits {
+        let extracted_data = extract_url_from_edit_data(edit.data);
+        if extracted_data.is_some() {
+            println!("{}", extracted_data.unwrap());
+        }
+    }
+    println!("Edit Notes ->");
+    for note in notes {
+        let urls = extract_urls_from_edit_note(note.text.as_str());
+        println!("{:?}", urls);
     }
     Ok(())
 }

--- a/src/poller/mod.rs
+++ b/src/poller/mod.rs
@@ -5,7 +5,7 @@ mod internet_archive_urls;
 use std::time::Duration;
 use sqlx::Row;
 use tokio::time::interval;
-use crate::poller::utils::extract_last_row_from_internet_archive_table;
+use crate::poller::utils::extract_last_rows_idx_from_internet_archive_table;
 
 pub struct Poller {
     poll_interval: u64,
@@ -18,12 +18,12 @@ impl Poller {
     pub async fn new(
         poll_interval: u64,
         pool: sqlx::PgPool) -> Poller {
-        let data_and_note =  extract_last_row_from_internet_archive_table(&pool).await;
+        let data_and_note =  extract_last_rows_idx_from_internet_archive_table(&pool).await;
         Poller {
             poll_interval,
             pool,
-            edit_data_start_idx: data_and_note[0].from_table_id.unwrap(),
-            edit_note_start_idx: data_and_note[1].from_table_id.unwrap()
+            edit_data_start_idx: data_and_note[0],
+            edit_note_start_idx: data_and_note[1]
         }
     }
     pub async fn poll(&mut self) {
@@ -33,6 +33,7 @@ impl Poller {
             if let Err(e) = looper::poll_db(&self.pool, self.edit_data_start_idx, self.edit_note_start_idx).await {
                 eprintln!("Error polling database: {}", e)
             } else {
+                //TODO: check the rate of edit data and edit note production, and increment the indices properly.
                 self.edit_data_start_idx = self.edit_data_start_idx + 10;
                 self.edit_note_start_idx = self.edit_note_start_idx + 10;
             }

--- a/src/poller/mod.rs
+++ b/src/poller/mod.rs
@@ -1,30 +1,40 @@
 mod looper;
 mod utils;
+mod internet_archive_urls;
 
 use std::time::Duration;
 use sqlx::Row;
 use tokio::time::interval;
+use crate::poller::utils::extract_last_row_from_internet_archive_table;
 
 pub struct Poller {
     poll_interval: u64,
-    pool: sqlx::PgPool
+    pool: sqlx::PgPool,
+    edit_note_start_idx: i32,
+    edit_data_start_idx: i32
 }
 
 impl Poller {
-    pub fn new(
+    pub async fn new(
         poll_interval: u64,
         pool: sqlx::PgPool) -> Poller {
+        let data_and_note =  extract_last_row_from_internet_archive_table(&pool).await;
         Poller {
             poll_interval,
-            pool
+            pool,
+            edit_data_start_idx: data_and_note[0].from_table_id.unwrap(),
+            edit_note_start_idx: data_and_note[1].from_table_id.unwrap()
         }
     }
-    pub async fn poll(&self) {
+    pub async fn poll(&mut self) {
         let mut interval = interval(Duration::from_secs(self.poll_interval));
         loop {
             interval.tick().await;
-            if let Err(e) = looper::poll_db(&self.pool).await {
+            if let Err(e) = looper::poll_db(&self.pool, self.edit_data_start_idx, self.edit_note_start_idx).await {
                 eprintln!("Error polling database: {}", e)
+            } else {
+                self.edit_data_start_idx = self.edit_data_start_idx + 10;
+                self.edit_note_start_idx = self.edit_note_start_idx + 10;
             }
         }
     }

--- a/src/poller/mod.rs
+++ b/src/poller/mod.rs
@@ -18,15 +18,13 @@ impl Poller {
             pool
         }
     }
-    pub fn poll(&self) {
-        tokio::spawn(async move {
-            let mut interval = interval(Duration::from_secs(self.poll_interval));
-            loop {
-                interval.tick().await;
-                if let Err(e) = looper::poll_db(&self.pool).await {
-                    eprintln!("Error polling database: {}", e)
-                }
+    pub async fn poll(&self) {
+        let mut interval = interval(Duration::from_secs(self.poll_interval));
+        loop {
+            interval.tick().await;
+            if let Err(e) = looper::poll_db(&self.pool).await {
+                eprintln!("Error polling database: {}", e)
             }
-        });
+        }
     }
 }

--- a/src/poller/mod.rs
+++ b/src/poller/mod.rs
@@ -1,4 +1,5 @@
 mod looper;
+mod utils;
 
 use std::time::Duration;
 use sqlx::Row;

--- a/src/poller/utils.rs
+++ b/src/poller/utils.rs
@@ -1,13 +1,17 @@
-use regex::Regex;
+use linkify::{LinkFinder, LinkKind};
+use serde_json::json;
+use sqlx::types::JsonValue;
 
 /// This function takes text from edit note and outputs a vector of URLs as string
 pub fn extract_urls_from_edit_note(note: &str) -> Vec<String> {
-    //TODO: test regex on more URLs
-    //Used regex mentioned here: https://stackoverflow.com/a/29288898/15084244
-    let re = Regex::new(r"(?:(?:https?|ftp|file):\/\/|www\.|ftp\.)(?:\([-A-Z0-9+&@#\/%=~_|$?!:,.]*\)|[-A-Z0-9+&@#\/%=~_|$?!:,.])*(?:\([-A-Z0-9+&@#\/%=~_|$?!:,.]*\)|[A-Z0-9+&@#\/%=~_|$])").unwrap();
-    re.find_iter(note)
-        .map(|mat| mat.as_str().to_string())
-        .collect()
+    let mut finder = LinkFinder::new();
+    finder.kinds(&[LinkKind::Url]);
+
+    let mut urls: Vec<_> = finder
+        .links(note)
+        .map(|link|{link.as_str().to_string()})
+        .collect();
+    urls
 }
 
 /// This function takes input a URL string, and returns true if it should exclude the URL from saving
@@ -15,4 +19,21 @@ pub fn should_exclude_url(url: &str) -> bool {
     // TODO: discuss and add keywords to identify URLs we want to exclude
     let keywords: Vec<String> = vec![];
     keywords.iter().any(|keyword| url.contains(keyword))
+}
+
+/// This function takes input Edit Data in form of JSONValue, checks if the Edit Data contains URL, and returns the URL as String
+pub fn extract_url_from_edit_data(json: JsonValue) -> Option<String> {
+    return if json.get("type1") == Some(&json!("url")) {
+        // Edit type: Add Relationship
+        let entity0 = json.get("entity1").unwrap();
+        Some(entity0.get("name").unwrap().to_string())
+    } else if json.get("new").is_some() && json.get("new").unwrap().is_object() {
+        //Edit type: Edit URL
+        let new = json.get("new").unwrap();
+        return if new.get("url").is_some() && new.get("url") != Some(&json!(null)) {
+            Some(new.get("url").unwrap().to_string())
+        } else { None }
+    } else {
+        None
+    }
 }

--- a/src/poller/utils.rs
+++ b/src/poller/utils.rs
@@ -1,0 +1,18 @@
+use regex::Regex;
+
+/// This function takes text from edit note and outputs a vector of URLs as string
+pub fn extract_urls_from_edit_note(note: &str) -> Vec<String> {
+    //TODO: test regex on more URLs
+    //Used regex mentioned here: https://stackoverflow.com/a/29288898/15084244
+    let re = Regex::new(r"(?:(?:https?|ftp|file):\/\/|www\.|ftp\.)(?:\([-A-Z0-9+&@#\/%=~_|$?!:,.]*\)|[-A-Z0-9+&@#\/%=~_|$?!:,.])*(?:\([-A-Z0-9+&@#\/%=~_|$?!:,.]*\)|[A-Z0-9+&@#\/%=~_|$])").unwrap();
+    re.find_iter(note)
+        .map(|mat| mat.as_str().to_string())
+        .collect()
+}
+
+/// This function takes input a URL string, and returns true if it should exclude the URL from saving
+pub fn should_exclude_url(url: &str) -> bool {
+    // TODO: discuss and add keywords to identify URLs we want to exclude
+    let keywords: Vec<String> = vec![];
+    keywords.iter().any(|keyword| url.contains(keyword))
+}


### PR DESCRIPTION
- This task is able to:
    - Initialize the `internet_archive_urls` table, fetch latest rows and columns from `edit_note` and `edit_data` tables, and add them to the `internet_archive_urls` table
    - Poll mb database, on each poll:
        - Extract the URLs from `edit_note` and `edit_data` tables,
        -  save them in the `internet_archive_urls` table. 
        - increment the rows for `edit_data` and `edit_note` tables to start polling again