### PR TITLE
refactor: Style fixes for idiomatic rust

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,68 +9,89 @@ mod utils;
 pub async fn start(pool: &PgPool) {
     let args = CliArgs::parse();
     match &args.command {
-        None => {
-            super::app::start(&pool).await.unwrap();
-        }
         Some(Commands::QueueEditData {
                  row_id
              }) => {
-            if row_id.is_none() {
+
+            // Argument check
+            // TODO: Concider making the argument mandatory by removing the `Option`?
+            let Some(row_id) = row_id else {
                 println!("{}", "Please pass row id".red());
                 return;
-            }
-            if let Ok(contains_urls) = utils::insert_edit_data_row_to_internet_archive_urls(row_id.unwrap(), &pool).await {
-                if contains_urls {
-                    println!("{} {}", "EditData's row enqueued successfully".green(), row_id.unwrap())
-                } else {
-                    println!("{}", "No URLs found".red())
-                }
-            } else {
-                println!("{}", "Some error occurred".red())
+            };
+
+            match utils::insert_edit_data_row_to_internet_archive_urls(*row_id, pool).await {
+                // We got urls!
+                Ok(true) => println!("{} {}", "EditData's row enqueued successfully".green(), row_id),
+
+                // We don't have urls
+                Ok(false) => println!("{}", "No URLs found".red()),
+
+                // Error
+                Err(err) => {
+                    println!("{}", "Some error occurred".red());
+                    eprintln!("{err}");
+                },
             }
         },
+
         Some(Commands::QueueEditNote {
                  row_id
              }) => {
-            if row_id.is_none() {
+            let Some(row_id) = row_id else {
                 println!("{}", "Please pass row id".red());
                 return;
-            }
-            if let Ok(contains_urls) = utils::insert_edit_note_row_to_internet_archive_urls(row_id.unwrap(), &pool).await {
-                if contains_urls {
-                    println!("{} {}", "EditNote's row enqueued successfully".green(), row_id.unwrap())
-                } else {
-                    println!("{}", "No URLs found".red())
+            };
+
+                match utils::insert_edit_note_row_to_internet_archive_urls(*row_id, pool).await {
+                    // We got urls!
+                    Ok(true) => println!("{} {}", "EditNote's row enqueued successfully".green(), row_id),
+    
+                    // We don't have urls
+                    Ok(false) => println!("{}", "No URLs found".red()),
+    
+                    // Error
+                    Err(err) => {
+                        println!("{}", "Some error occurred".red());
+                        eprintln!("{err}");
+                    },
                 }
-            } else {
-                println!("{}", "Some error occurred".red())
-            }
         },
+
         Some(Commands::QueueURL {
                  url
              }) => {
-            if url.is_none() {
+            let Some(url) = url else {
                 println!("{}", "Please pass URL".red());
                 return;
-            }
-            if let Ok(id) = utils::insert_url_to_internet_archive_urls(url.clone().unwrap(), &pool).await {
-                println!("{} {}", "URL queued in internet_archive_urls, id: ".green(), id)
-            } else {
-                println!("{}", "Some error occurred".red())
+            };
+
+            match utils::insert_url_to_internet_archive_urls(url, pool).await {
+                Ok(id) => println!("{} {}", "URL queued in internet_archive_urls, id: ".green(), id),
+
+                // Error
+                Err(err) => {
+                    println!("{}", "Some error occurred".red());
+                    eprintln!("{err}");
+                },
             }
         },
+
         Some(Commands::CheckStatus {
                  job_id
              }) => {
-            if job_id.is_none() {
+            let Some(job_id) = job_id else {
                 println!("{}", "Please pass job id".red());
                 return;
-            }
+            };
+
             println!("{:?}", job_id);
-            utils::get_job_id_status(job_id.clone().unwrap(), &pool).await.unwrap();
+
+            utils::get_job_id_status(job_id.clone(), pool).await.unwrap();
         },
-        Some(Commands::Poll) => {
-            super::app::start(&pool).await.unwrap();
+
+        Some(Commands::Poll) | None => {
+            super::app::start(pool).await.unwrap();
         }
     }
 }

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -5,7 +5,7 @@ use crate::poller;
 
 //TODO: Currently I am returning the internet_archive_urls row id when I insert any URL. Now there might be URLs which are already saved, hence instead of row id, show how many URLs are still there unprocessed, and is before the currently inserted one.
 pub async fn insert_url_to_internet_archive_urls(
-    url: String,
+    url: &str,
     pool: &PgPool,
 ) -> Result<i32, Error> {
     let id = sqlx::query!(
@@ -85,8 +85,9 @@ pub async fn insert_edit_note_row_to_internet_archive_urls(
 
 }
 
+// TODO
 pub async fn get_job_id_status(
-    job_id: String,
+    job_id: String, // TODO: Concider using &str? 
     _pool: &PgPool
 ) -> Result<&str, Error> {
     println!("job_id: {},", job_id);

--- a/src/poller/looper.rs
+++ b/src/poller/looper.rs
@@ -67,16 +67,10 @@ pub async fn poll_db(
             println!("{}", url);
         }
     }
-    // Check ids to start the next poll with, and return them
-    let last_edit_note_row_from_single_poll: Option<&EditNote> = notes.last();
-    let last_edit_data_row_from_single_poll: Option<&EditData> = edits.last();
-    let mut new_edit_id: Option<i32> = None;
-    let mut new_note_id: Option<i32> = None;
-    if last_edit_data_row_from_single_poll.is_some() {
-        new_edit_id = Some(last_edit_data_row_from_single_poll.unwrap().edit + 1);
-    }
-    if last_edit_note_row_from_single_poll.is_some() {
-        new_note_id = Some(last_edit_note_row_from_single_poll.unwrap().id + 1);
-    }
-    Ok((new_edit_id, new_note_id))
+
+    // Return the next ids of the last edit and notes for the next poll
+    Ok((
+        edits.last().map(|edit| edit.edit + 1),
+        notes.last().map(|note| note.id + 1)
+    ))
 }

--- a/src/poller/utils.rs
+++ b/src/poller/utils.rs
@@ -17,23 +17,22 @@ pub fn extract_urls_from_text(text: &str) -> Vec<String> {
     urls
 }
 
-/// This function takes input Edit Data in form of JSONValue, checks if the Edit Data contains URL, and returns the URL as String
+/// This function get the urls contained in the input edit data.
+///
+/// Depending on the type of edit data, it will give one or many urls:
+///  - "Add" and "edit" edits will give 1 url, as the edit concern a 1:1 relation between an entity and an Url
+///  - Annotations provide multiple Urls as it is arbitrary text made by the editor.
+/// 
+/// The input edit data is in [`JsonValue`] form.
 pub fn extract_url_from_edit_data(json: &JsonValue) -> Vec<String> {
-    let mut result: Vec<String> = vec![];
-    if add_relationship_type0_url(&json).is_some() {
-        result.push(add_relationship_type0_url(&json).unwrap());
-    } else if add_relationship_type1_url(&json).is_some() {
-        result.push(add_relationship_type1_url(&json).unwrap());
-    } else if edit_relationship_type0_url(&json).is_some() {
-        result.push(edit_relationship_type0_url(&json).unwrap());
-    } else if edit_relationship_type1_url(&json).is_some() {
-        result.push(edit_relationship_type1_url(&json).unwrap());
-    } else if edit_url(&json).is_some() {
-        result.push(edit_url(&json).unwrap());
-    } else if any_annotation(&json).is_some() {
-        result.append(&mut any_annotation(&json).unwrap());
-    }
-    result
+    None.or_else(|| add_relationship_type0_url(json))
+        .or_else(|| add_relationship_type1_url(json))
+        .or_else(|| edit_relationship_type0_url(json))
+        .or_else(|| edit_relationship_type1_url(json))
+        .or_else(|| edit_url(json))
+        .map(|single_url| vec![single_url])
+        .or_else(|| any_annotation(json))
+        .unwrap_or_default()
 }
 
 fn add_relationship_type1_url(json: &JsonValue) -> Option<String> {


### PR DESCRIPTION
This PR is meant to help cleanup the codebase with more idiomatic rust, and improve code smell with good practices.

# Changes
- `extract_url_from_edit_data` has been changed to use method chaining on a `Option<>` value to prevent `else if` repetition, as well as repeat call to the concerned function. The documentation string have been extended for further clarification.

# Discussion
I intend to add more changes so this is only a draft PR for now. The functions to extract the url(s) definitely need a rework. I do have a question however

I see that the function uses `JsonValue`s to get the url fields. Is there any particular reason as to why use it in place of structs representing the json data? I would argue that it's clearer to use structs as it is able to represent our data as types instead of try to get fields from strings that may or may not be there, or would break at runtime at the slightness renaming
