### PR TITLE
refactor: Poller cleanup

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -46,7 +46,7 @@ pub async fn spawn_poller_task(db_pool: PgPool) -> JoinHandle<()> {
         .expect("[POLLER] Could not find rows in edit rows to start poller");
 
     tokio::spawn(async move {
-        if let Err(e) = poller.poll().await {
+        if let Err(e) = poller.run().await {
             error!("[POLLER] Task Failed, Error: {}", e);
             sentry::capture_error(&e);
         }


### PR DESCRIPTION
I refactored the poller module to add some comments and make the code more readable. No behaviour should be changed

Haven't personally tested it, but the inbeded test should be enough.

I'll try to test it myself as soon I manage to install the MB docker on a separate disk